### PR TITLE
Correção em ToDict()

### DIFF
--- a/classes/functions.py
+++ b/classes/functions.py
@@ -48,6 +48,10 @@ def toDict(self, archive, colunas):
                 date = "-".join(date)
             else:
                 date = date.replace("/","-") 
+            if '.' in time:
+                x = str.index(time, '.')
+                time = time[:x]
+                
             timedate = datetime.fromisoformat(date + ' ' + time)
 
         except ValueError:


### PR DESCRIPTION
função datetime.datetime.fromisoformat() nao aceitava strings do tipo: "2020-12-01 00:20:00.00"
Corrigido para ignorar a parcela após o ponto '.'